### PR TITLE
using git based cleaner instead of os based

### DIFF
--- a/commitserver/commit/commit.go
+++ b/commitserver/commit/commit.go
@@ -118,10 +118,24 @@ func (s *Service) handleCommitRequest(logCtx *log.Entry, r *apiclient.CommitHydr
 		return out, "", fmt.Errorf("failed to checkout target branch: %w", err)
 	}
 
+<<<<<<< HEAD
 	logCtx.Debug("Clearing repo contents")
 	out, err = gitClient.RemoveContents()
 	if err != nil {
 		return out, "", fmt.Errorf("failed to clear repo: %w", err)
+=======
+	logCtx.Debug("Clearing and preparing paths")
+	for _, p := range r.Paths {
+		if p.Path == "" || p.Path == "." {
+			logCtx.Debug("Using root directory for manifests, no directory removal needed")
+		} else {
+			logCtx.Debugf("Clearing path %s", p.Path)
+			out, err := gitClient.RemoveContents(p.Path)
+			if err != nil {
+				return out, "", fmt.Errorf("failed to clear path %s: %w", p.Path, err)
+			}
+		}
+>>>>>>> 8f7860168 (using git based cleaner instead of os based)
 	}
 
 	logCtx.Debug("Writing manifests")

--- a/commitserver/commit/commit_test.go
+++ b/commitserver/commit/commit_test.go
@@ -109,6 +109,173 @@ func Test_CommitHydratedManifests(t *testing.T) {
 		require.NotNil(t, resp)
 		assert.Equal(t, "it-worked!", resp.HydratedSha)
 	})
+<<<<<<< HEAD
+=======
+
+	t.Run("root path with dot and blank - no directory removal", func(t *testing.T) {
+		t.Parallel()
+
+		service, mockRepoClientFactory := newServiceWithMocks(t)
+		mockGitClient := gitmocks.NewClient(t)
+		mockGitClient.On("Init").Return(nil).Once()
+		mockGitClient.On("Fetch", mock.Anything).Return(nil).Once()
+		mockGitClient.On("SetAuthor", "Argo CD", "argo-cd@example.com").Return("", nil).Once()
+		mockGitClient.On("CheckoutOrOrphan", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CheckoutOrNew", "main", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CommitAndPush", "main", "test commit message").Return("", nil).Once()
+		mockGitClient.On("CommitSHA").Return("root-and-blank-sha", nil).Once()
+		mockRepoClientFactory.On("NewClient", mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
+
+		requestWithRootAndBlank := &apiclient.CommitHydratedManifestsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: "https://github.com/argoproj/argocd-example-apps.git",
+			},
+			TargetBranch:  "main",
+			SyncBranch:    "env/test",
+			CommitMessage: "test commit message",
+			Paths: []*apiclient.PathDetails{
+				{
+					Path: ".",
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-dot"}}`,
+						},
+					},
+				},
+				{
+					Path: "",
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"test-blank"}}`,
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := service.CommitHydratedManifests(t.Context(), requestWithRootAndBlank)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "root-and-blank-sha", resp.HydratedSha)
+	})
+
+	t.Run("subdirectory path - triggers directory removal", func(t *testing.T) {
+		t.Parallel()
+
+		service, mockRepoClientFactory := newServiceWithMocks(t)
+		mockGitClient := gitmocks.NewClient(t)
+		mockGitClient.On("Init").Return(nil).Once()
+		mockGitClient.On("Fetch", mock.Anything).Return(nil).Once()
+		mockGitClient.On("SetAuthor", "Argo CD", "argo-cd@example.com").Return("", nil).Once()
+		mockGitClient.On("CheckoutOrOrphan", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CheckoutOrNew", "main", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("RemoveContents", "apps/staging").Return("", nil).Once()
+		mockGitClient.On("CommitAndPush", "main", "test commit message").Return("", nil).Once()
+		mockGitClient.On("CommitSHA").Return("subdir-path-sha", nil).Once()
+		mockRepoClientFactory.On("NewClient", mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
+
+		requestWithSubdirPath := &apiclient.CommitHydratedManifestsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: "https://github.com/argoproj/argocd-example-apps.git",
+			},
+			TargetBranch:  "main",
+			SyncBranch:    "env/test",
+			CommitMessage: "test commit message",
+			Paths: []*apiclient.PathDetails{
+				{
+					Path: "apps/staging", // subdirectory path
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"test-app"}}`,
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := service.CommitHydratedManifests(t.Context(), requestWithSubdirPath)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "subdir-path-sha", resp.HydratedSha)
+	})
+
+	t.Run("mixed paths - root and subdirectory", func(t *testing.T) {
+		t.Parallel()
+
+		service, mockRepoClientFactory := newServiceWithMocks(t)
+		mockGitClient := gitmocks.NewClient(t)
+		mockGitClient.On("Init").Return(nil).Once()
+		mockGitClient.On("Fetch", mock.Anything).Return(nil).Once()
+		mockGitClient.On("SetAuthor", "Argo CD", "argo-cd@example.com").Return("", nil).Once()
+		mockGitClient.On("CheckoutOrOrphan", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CheckoutOrNew", "main", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("RemoveContents", "apps/production").Return("", nil).Once()
+		mockGitClient.On("CommitAndPush", "main", "test commit message").Return("", nil).Once()
+		mockGitClient.On("CommitSHA").Return("mixed-paths-sha", nil).Once()
+		mockRepoClientFactory.On("NewClient", mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
+
+		requestWithMixedPaths := &apiclient.CommitHydratedManifestsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: "https://github.com/argoproj/argocd-example-apps.git",
+			},
+			TargetBranch:  "main",
+			SyncBranch:    "env/test",
+			CommitMessage: "test commit message",
+			Paths: []*apiclient.PathDetails{
+				{
+					Path: ".", // root path - should NOT trigger removal
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"global-config"}}`,
+						},
+					},
+				},
+				{
+					Path: "apps/production", // subdirectory path - SHOULD trigger removal
+					Manifests: []*apiclient.HydratedManifestDetails{
+						{
+							ManifestJSON: `{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"prod-app"}}`,
+						},
+					},
+				},
+			},
+		}
+
+		resp, err := service.CommitHydratedManifests(t.Context(), requestWithMixedPaths)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "mixed-paths-sha", resp.HydratedSha)
+	})
+
+	t.Run("empty paths array", func(t *testing.T) {
+		t.Parallel()
+
+		service, mockRepoClientFactory := newServiceWithMocks(t)
+		mockGitClient := gitmocks.NewClient(t)
+		mockGitClient.On("Init").Return(nil).Once()
+		mockGitClient.On("Fetch", mock.Anything).Return(nil).Once()
+		mockGitClient.On("SetAuthor", "Argo CD", "argo-cd@example.com").Return("", nil).Once()
+		mockGitClient.On("CheckoutOrOrphan", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CheckoutOrNew", "main", "env/test", false).Return("", nil).Once()
+		mockGitClient.On("CommitAndPush", "main", "test commit message").Return("", nil).Once()
+		mockGitClient.On("CommitSHA").Return("it-worked!", nil).Once()
+		mockRepoClientFactory.On("NewClient", mock.Anything, mock.Anything).Return(mockGitClient, nil).Once()
+
+		requestWithEmptyPaths := &apiclient.CommitHydratedManifestsRequest{
+			Repo: &v1alpha1.Repository{
+				Repo: "https://github.com/argoproj/argocd-example-apps.git",
+			},
+			TargetBranch:  "main",
+			SyncBranch:    "env/test",
+			CommitMessage: "test commit message",
+		}
+
+		resp, err := service.CommitHydratedManifests(t.Context(), requestWithEmptyPaths)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "it-worked!", resp.HydratedSha)
+	})
+>>>>>>> 8f7860168 (using git based cleaner instead of os based)
 }
 
 func newServiceWithMocks(t *testing.T) (*Service, *mocks.RepoClientFactory) {

--- a/util/git/client.go
+++ b/util/git/client.go
@@ -129,7 +129,7 @@ type Client interface {
 	// the base branch.
 	CheckoutOrNew(branch, base string, submoduleEnabled bool) (string, error)
 	// RemoveContents removes all files from the git repository.
-	RemoveContents() (string, error)
+	RemoveContents(path string) (string, error)
 	// CommitAndPush commits and pushes changes to the target branch.
 	CommitAndPush(branch, message string) (string, error)
 }
@@ -1022,11 +1022,11 @@ func (m *nativeGitClient) CheckoutOrNew(branch, base string, submoduleEnabled bo
 	return "", nil
 }
 
-// RemoveContents removes all files from the git repository.
-func (m *nativeGitClient) RemoveContents() (string, error) {
-	out, err := m.runCmd("rm", "-r", "--ignore-unmatch", ".")
+// RemoveContents removes all files from the path of git repository.
+func (m *nativeGitClient) RemoveContents(path string) (string, error) {
+	out, err := m.runCmd("rm", "-r", "--ignore-unmatch", path)
 	if err != nil {
-		return out, fmt.Errorf("failed to clear repo contents: %w", err)
+		return out, fmt.Errorf("failed to clear path %s: %w", path, err)
 	}
 	return "", nil
 }

--- a/util/git/client_test.go
+++ b/util/git/client_test.go
@@ -803,12 +803,6 @@ func Test_nativeGitClient_CheckoutOrNew(t *testing.T) {
 }
 
 func Test_nativeGitClient_RemoveContents(t *testing.T) {
-	// Example status
-	// 2 files :
-	//   * <RepoRoot>/README.md
-	//   * <RepoRoot>/scripts/startup.sh
-
-	// given
 	tempDir, err := _createEmptyGitRepo()
 	require.NoError(t, err)
 
@@ -836,14 +830,16 @@ func Test_nativeGitClient_RemoveContents(t *testing.T) {
 	err = runCmd(client.Root(), "git", "commit", "-m", "Make files")
 	require.NoError(t, err)
 
-	// when
-	out, err = client.RemoveContents()
-	require.NoError(t, err, "error output: ", out)
-
-	// then
-	ls, err := outputCmd(client.Root(), "ls", "-l")
+	// when: remove only "scripts" directory
+	_, err = client.RemoveContents("scripts")
 	require.NoError(t, err)
-	require.Equal(t, "total 0", strings.TrimSpace(string(ls)))
+
+	// then: "scripts" should be gone, "README.md" should still exist
+	_, err = os.Stat(filepath.Join(client.Root(), "README.md"))
+	require.NoError(t, err, "README.md should not be removed")
+
+	_, err = os.Stat(filepath.Join(client.Root(), "scripts"))
+	require.Error(t, err, "scripts directory should be removed")
 }
 
 func Test_nativeGitClient_CommitAndPush(t *testing.T) {

--- a/util/git/mocks/Client.go
+++ b/util/git/mocks/Client.go
@@ -863,8 +863,8 @@ func (_c *Client_LsRemote_Call) RunAndReturn(run func(revision string) (string, 
 }
 
 // RemoveContents provides a mock function for the type Client
-func (_mock *Client) RemoveContents() (string, error) {
-	ret := _mock.Called()
+func (_mock *Client) RemoveContents(path string) (string, error) {
+	ret := _mock.Called(path)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveContents")
@@ -872,16 +872,16 @@ func (_mock *Client) RemoveContents() (string, error) {
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return returnFunc(path)
 	}
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(string) string); ok {
+		r0 = returnFunc(path)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(path)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -894,13 +894,20 @@ type Client_RemoveContents_Call struct {
 }
 
 // RemoveContents is a helper method to define mock.On call
-func (_e *Client_Expecter) RemoveContents() *Client_RemoveContents_Call {
-	return &Client_RemoveContents_Call{Call: _e.mock.On("RemoveContents")}
+//   - path string
+func (_e *Client_Expecter) RemoveContents(path interface{}) *Client_RemoveContents_Call {
+	return &Client_RemoveContents_Call{Call: _e.mock.On("RemoveContents", path)}
 }
 
-func (_c *Client_RemoveContents_Call) Run(run func()) *Client_RemoveContents_Call {
+func (_c *Client_RemoveContents_Call) Run(run func(path string)) *Client_RemoveContents_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -910,7 +917,7 @@ func (_c *Client_RemoveContents_Call) Return(s string, err error) *Client_Remove
 	return _c
 }
 
-func (_c *Client_RemoveContents_Call) RunAndReturn(run func() (string, error)) *Client_RemoveContents_Call {
+func (_c *Client_RemoveContents_Call) RunAndReturn(run func(path string) (string, error)) *Client_RemoveContents_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Title of the PR](https://argo-cd.readthedocs.io/en/latest/developer-guide/submit-your-pr/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)).
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] Optional. My organization is added to USERS.md.
* [ ] Optional. For bug fixes, I've indicated what older releases this fix should be cherry-picked into (this may or may not happen depending on risk/complexity).

<!-- Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request. -->
